### PR TITLE
Facility detail html fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ## Local dev ignores
 local/
 
+## Ignore `staticfiles` folder generation from production
+staticfiles/
+
 ## Odd new `cache` ignore?
 
 *cache*

--- a/home/templates/facility_detail.html
+++ b/home/templates/facility_detail.html
@@ -16,7 +16,7 @@
                     <ul class="list-group list-group-flush">
                         <li class="list-group-item"><i class="fas fa-map-marker-alt"></i> <strong>Location:</strong> {{ facility_address }}</li>
                         <li class="list-group-item"><i class="fas fa-campground"></i> <strong>Type:</strong> {{ campsite.FacilityTypeDescription }}</li>
-                        <li class="list-group-item"><i class="fas fa-info-circle"></i> <strong>Description:</strong> {{ campsite.FacilityDescription|default:"N/A" }}</li>
+                        <li class="list-group-item"><i class="fas fa-info-circle"></i> <strong>Description:</strong> {{ campsite.FacilityDescription|default:"N/A"|safe }}</li>
                     </ul>
                 </div>
                 <div class="col-md-6">


### PR DESCRIPTION
small fix which should let html tags pulled in via the rec.gov api to render properly/safely when displayed on the facility_detail webview.

includes an addition to .gitignore to ignore staticfiles folder, generated before running the server w/ `python manage.py collectstatic`

before:
![image](https://github.com/user-attachments/assets/6ad4ef57-3cf6-4685-88c0-f7a1de47ad9e)


after:
![image](https://github.com/user-attachments/assets/d4f0f100-286e-4191-becd-9b6e9634f1ba)
